### PR TITLE
Test workflow dispatch

### DIFF
--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -3,7 +3,7 @@ name: Trigger dispatch-b's package update
 on:
     workflow_run:
         workflows:
-          - Pull Request workflow
+          - 'Pull Request workflow'
         types:
           - completed
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# Workflow dispatch testing sender
+### Workflow dispatch testing sender


### PR DESCRIPTION
dispatch-a triggered dispatch-b's receiver.yml, but the workflow was skipped...

Oh, that's neat. The `if` condition in receiver.yml was wrong. Working!

Notes:
* Create new fine grained PAT for `dispatch-b` with Actions (RW), Contents (RW), Metadata (R) and Pull Requests (RW)
* Add PAT to dispatch-a and dispatch-b as secrets
* The trigger workflow in dispatch-a must already exist in `main` for `workflow_run` to work
